### PR TITLE
reworking noderef to propagate main type as being interface; ts throw…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tparserr",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "Typescript Type Parser",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/Extractor.ts
+++ b/src/lib/Extractor.ts
@@ -67,7 +67,7 @@ class Extractor {
     private capture(symbol: ts.Symbol, node: ts.Node, type: ts.Type): void {
         const typeName = Type.extractTypeName(symbol);
 
-        this.allNodeRefsMap[typeName] = { node, type };
+        this.allNodeRefsMap[typeName] = { node, type, isInterface: Check.isInterface(node) };
         this.mainEntityNames.push(typeName);
     }
 

--- a/src/lib/types/NodeRef.ts
+++ b/src/lib/types/NodeRef.ts
@@ -7,6 +7,8 @@ export interface INodeRef {
     type: ts.Type;
 
     child?: boolean;
+
+    isInterface: boolean;
 }
 
 export type TNodeRefMap = Record<string, INodeRef>;

--- a/src/lib/typescript/Check.ts
+++ b/src/lib/typescript/Check.ts
@@ -7,12 +7,12 @@ import Session from '../utils/Session';
 class Check {
 
     public isClassOrInterfaceKind(node: ts.Node): boolean {
-        return node.kind === ts.SyntaxKind.ClassDeclaration ||
+        return node?.kind === ts.SyntaxKind.ClassDeclaration ||
             this.isInterface(node)
     }
 
     public isInterface(node: ts.Node): boolean {
-        return node.kind === ts.SyntaxKind.InterfaceDeclaration;
+        return node?.kind === ts.SyntaxKind.InterfaceDeclaration;
     }
 
     public isExport(node: ts.Declaration | ts.Node): boolean {

--- a/src/lib/typescript/Decorator.ts
+++ b/src/lib/typescript/Decorator.ts
@@ -2,8 +2,6 @@
 import _ from 'lodash';
 import * as ts from 'typescript';
 
-import Check from './Check';
-
 import { INodeRef } from '../types/NodeRef';
 import { IAnnotation } from '../types/ITypeDescription';
 
@@ -11,9 +9,7 @@ import { IAnnotation } from '../types/ITypeDescription';
 class Decorator {
 
     public extractClassDecorators(nodeRef: INodeRef): Array<IAnnotation> {
-        if (Check.isInterface(nodeRef.node)) {
-            return;
-        }
+        if (nodeRef.isInterface) { return; }
 
         const decorators = ts.canHaveDecorators(nodeRef.node) ? ts.getDecorators(nodeRef.node) : [];
 


### PR DESCRIPTION
…s when canHaveDecorators is called on an interface node, even if nested